### PR TITLE
Add input validation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,7 @@ dependencies = [
  "polyfit-rs",
  "rand",
  "rand_distr",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ ndarray-interp = "0"
 rand = "0"
 rand_distr = "0"
 polyfit-rs = "0"
+thiserror = "1"
 
 [dev-dependencies]
 approx = "0"


### PR DESCRIPTION
Summary
----
This adds `thiserror` to check for input validation.
- x or y cannot be empty
- x and y both should have equal length

`KneeLocator::ParamError(msg)` would be raised otherwise and no further action would be done.